### PR TITLE
Update ea4_main.default

### DIFF
--- a/SOURCES/ea4_main.default
+++ b/SOURCES/ea4_main.default
@@ -98,7 +98,7 @@ RewriteEngine on
 RewriteCond %{REQUEST_URI} [% mod_rewrite_string_escape(pattern) %] [% !loop.last && '[OR]' %]
 [% END -%]
 [% IF all_possible_proxy_subdomains_regex %]
-# Exclude proxy subdomains as we need rewrites to capture the DCV requests
+# Exclude proxy subdomains as we eed rewrites to capture the DCV requests
 RewriteCond %{HTTP_HOST} !^(?:[% all_possible_proxy_subdomains_regex %])\.
 [% END -%]
 RewriteRule ^ - [END]
@@ -128,7 +128,7 @@ RLimitMEM [% main.rlimitmem.item.softrlimitmem %] [% mainrlimitmem.item.maxrlimi
 </Directory>
 
 # Required cPanel security policy: Disallow remote access to .htaccess, .htpasswd, .user.ini, and php.ini files
-<FilesMatch "^(\.ht(access|passwds?)|\.user\.ini|php\.ini)$">
+<FilesMatch "\/(\.ht(access|passwds?)|\.user\.ini|php\.ini)$">
     Require all denied
 </FilesMatch>
 

--- a/SOURCES/ea4_main.default
+++ b/SOURCES/ea4_main.default
@@ -98,7 +98,7 @@ RewriteEngine on
 RewriteCond %{REQUEST_URI} [% mod_rewrite_string_escape(pattern) %] [% !loop.last && '[OR]' %]
 [% END -%]
 [% IF all_possible_proxy_subdomains_regex %]
-# Exclude proxy subdomains as we eed rewrites to capture the DCV requests
+# Exclude proxy subdomains as we need rewrites to capture the DCV requests
 RewriteCond %{HTTP_HOST} !^(?:[% all_possible_proxy_subdomains_regex %])\.
 [% END -%]
 RewriteRule ^ - [END]


### PR DESCRIPTION
the "fixed" regex would not have matched anything in a subdirectory, resulting in this:

```
[root@host /home/redacted/public_html]# curl https://redacted.com/testdir/php.ini
abcd
```

Now it will match the files in the subdirectories properly.