### PR TITLE
Remove ancient MSIE hacks for keepalives.

### DIFF
--- a/SOURCES/ssl_vhost.default
+++ b/SOURCES/ssl_vhost.default
@@ -172,7 +172,6 @@
 [% IF supported.stapling && !has_ocsp(vhost.sslcertificatefile) -%]
     SSLUseStapling off
 [% END -%]
-    SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown
     <Directory "[% vhost.documentroot %]/cgi-bin">
       SSLOptions +StdEnvVars
     </Directory>


### PR DESCRIPTION
Windows XP/2003 w/ IE 5 and lower had a SSL keepalive bug. Some changes were set in place within Apache 1.3/2.0 that tried to work around this bug. 

MSDN says this workaround can be removed:

https://web.archive.org/web/20150221075545/http://blogs.msdn.com/b/ieinternals/archive/2011/03/26/https-and-connection-close-is-your-apache-modssl-server-configuration-set-to-slow.aspx

IE1-5 doesn't even support TLS1.1/1.2 or anything else nowadays because it's insecure, outdated. 

https://en.wikipedia.org/wiki/Version_history_for_TLS/SSL_support_in_web_browsers